### PR TITLE
fix for create table engine ReplicatedReplacingMergeTree

### DIFF
--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -248,8 +248,8 @@ func (ch *ClickHouse) ensureVersionTable() (err error) {
 			) Engine=%s`, ch.config.MigrationsTable, ch.config.MigrationsTableEngine)
 	}
 
-	if strings.HasSuffix(ch.config.MigrationsTableEngine, "Tree") {
-		query = fmt.Sprintf(`%s ORDER BY sequence`, query)
+	if strings.Contains(ch.config.MigrationsTableEngine, "Tree") {
+		query = fmt.Sprintf(`%s PRIMARY KEY sequence ORDER BY sequence`, query)
 	}
 
 	if _, err := ch.conn.Exec(query); err != nil {


### PR DESCRIPTION
Fix for `x-migrations-table-engine=ReplicatedReplacingMergeTree`
```sh
2024/09/18 22:32:32 error: failed to open database, "clickhouse://localhost:9440/?username=xxx&password=xxx&secure=1&skip_verify=1&debug=1&x-migrations-table=MIGRATE_SCHEMA_MIGRATIONS&x-migrations-table-engine=ReplicatedReplacingMergeTree('/clickhouse/tables/xxx/MIGRATE_SCHEMA_MIGRATIONS','{replica}')&x-cluster-name=xxxx":
 code: 42, message: There was an error on [chi-replicated-xxxx-0-0:9440]:
Code: 42. DB::Exception: ORDER BY or PRIMARY KEY clause is missing.
Consider using extended storage definition syntax with ORDER BY or PRIMARY KEY clause.
```
this patch makes so:
```sql
CREATE TABLE MIGRATE_SCHEMA_MIGRATIONS ON CLUSTER otel (
   version    Int64,
   dirty      UInt8,
   sequence   UInt64
) Engine=ReplicatedReplacingMergeTree('/clickhouse/tables/otel/MIGRATE_SCHEMA_MIGRATIONS','{replica}')
PRIMARY KEY sequence
ORDER BY sequence
```
you can connect to any node and deploy everything at once